### PR TITLE
Fix wrong angle calculation in AngularDistanceMetric (atan -> atan2)

### DIFF
--- a/src/salsa/train/metrics.py
+++ b/src/salsa/train/metrics.py
@@ -93,8 +93,8 @@ class AngularDistanceMetric(torchmetrics.Metric):
     def update(self, outputs, targets) -> None:
         _, cols = outputs.shape
         assert cols == 2, f"outputs should have 2 columns, not {cols}"
-        pred_angles = torch.atan(outputs[:, 0] / outputs[:, 1])
-        tgt_angles = torch.atan(targets[:, 0] / targets[:, 1])
+        pred_angles = torch.atan2(outputs[:, 1], outputs[:, 0])
+        tgt_angles = torch.atan2(targets[:, 1], targets[:, 0])
         diff = torch.abs(pred_angles - tgt_angles)
         self.sum_dist += torch.mean(torch.minimum(diff, torch.pi * 2 - diff))
         self.total_batches += 1


### PR DESCRIPTION
While going through the angular embedding code I noticed `AngularDistanceMetric.update()` in `metrics.py` is computing the angle wrong.

The encoder stacks `(cos(θ), sin(θ))` as the two output columns (see `AngularEncoder.encode` in `lattice.py`, line 111). But the metric does this:

```python
pred_angles = torch.atan(outputs[:, 0] / outputs[:, 1])
tgt_angles = torch.atan(targets[:, 0] / targets[:, 1])
```

That's `atan(cos/sin)`, i.e. `atan(cot(θ))` — not `θ`. Two problems with this:

- `cot(θ)` repeats every `π` radians, not `2π`. So two angles that are exactly opposite each other on the circle (the worst possible case, `θ` vs `θ + π`) come out as the *same* value here, meaning the metric reports basically zero error in the worst case.
- it blows up when `sin(θ) = 0`.

I checked, and the rest of the codebase actually does this correctly — both `AngularEncoder.decode` (lattice.py, line 119) and `CoordinatesHead.to_angle` (encoder.py, line 243) use `atan2(col1, col0)` with the same column layout. This one spot just didn't follow that pattern.

Fix is just swapping the two lines for `atan2`:

```python
pred_angles = torch.atan2(outputs[:, 1], outputs[:, 0])
tgt_angles = torch.atan2(targets[:, 1], targets[:, 0])
```

To check it actually matters, I ran the real class with two angles π apart (max possible distance, so the answer should be π):

before: 9.93e-08   (basically zero, wrong)

after:  3.14159... (correct)

Ran this by importing `AngularDistanceMetric` directly, not a reimplementation:

```python
from src.salsa.train.metrics import AngularDistanceMetric
import torch, math

theta_pred = torch.tensor([1.0, 0.5, 2.0])
theta_tgt  = torch.tensor([1.0 + math.pi, 0.5 + math.pi, 2.0 + math.pi])
outputs = torch.stack([torch.cos(theta_pred), torch.sin(theta_pred)], dim=-1)
targets = torch.stack([torch.cos(theta_tgt),  torch.sin(theta_tgt)],  dim=-1)

m = AngularDistanceMetric()
m.update(outputs, targets)
print(m.compute().item())
```

One thing worth flagging so it's clear what this does and doesn't affect: this metric is only used for logging (`train/angle` / `recover/angle` in the `MetricCollection`). The actual training loss is `MSELoss` on the raw `(cos, sin)` vectors directly, and secret recovery goes through `io_encoder.decode()` which already uses the correct `atan2` — neither of those touch this metric at all. So this doesn't change training behavior or recovery results, it just fixes a number that gets printed to the logs. Wanted to be upfront about that so the scope is clear.