### PR TITLE
Fix onboarding blockers

### DIFF
--- a/src/cruel_cool/reduction.py
+++ b/src/cruel_cool/reduction.py
@@ -49,7 +49,7 @@ def reduce_with_flatter(Ap, alpha=0.025):
     env = os.environ.copy()
     env["OMP_NUM_THREADS"] = "1"
     try:
-        p = Popen(["flatter", "-alpha", str(alpha)], stdin=PIPE, stdout=PIPE, env=env)
+        p = Popen([flatter_path, "-alpha", str(alpha)], stdin=PIPE, stdout=PIPE, env=env)
     except Exception as e:
         raise RuntimeError(
             f"'flatter' was found at '{flatter_path}' but could not be launched."

--- a/src/cruel_cool/reduction.py
+++ b/src/cruel_cool/reduction.py
@@ -44,7 +44,7 @@ def reduce_with_flatter(Ap, alpha=0.025):
     try:
         p = Popen(["flatter", "-alpha", str(alpha)], stdin=PIPE, stdout=PIPE, env=env)
     except Exception as e:
-        logger.error(f"flatter failed with error {e}")
+        raise RuntimeError("Could not launch 'flatter'. Is it installed and on PATH?") from e
     out, _ = p.communicate(input=fplll_Ap_encoded)  # output from the flatter run.
     Ap = decode_intmat(out)
     return Ap

--- a/src/cruel_cool/reduction.py
+++ b/src/cruel_cool/reduction.py
@@ -8,6 +8,7 @@ LICENSE file in the root directory of this source tree.
 
 from logging import getLogger
 import os
+import shutil
 import numpy as np
 from subprocess import Popen, PIPE
 import sys
@@ -39,12 +40,20 @@ def reduce_with_flatter(Ap, alpha=0.025):
     """
     fplll_Ap = IntegerMatrix.from_matrix(Ap.tolist())
     fplll_Ap_encoded = encode_intmat(fplll_Ap)
+    flatter_path = shutil.which("flatter")
+    if flatter_path is None:
+        raise RuntimeError(
+            "'flatter' not found on PATH. Install it and make sure it is on your PATH. "
+            "See https://github.com/keeganryan/flatter"
+        )
     env = os.environ.copy()
     env["OMP_NUM_THREADS"] = "1"
     try:
         p = Popen(["flatter", "-alpha", str(alpha)], stdin=PIPE, stdout=PIPE, env=env)
     except Exception as e:
-        raise RuntimeError("Could not launch 'flatter'. Is it installed and on PATH?") from e
+        raise RuntimeError(
+            f"'flatter' was found at '{flatter_path}' but could not be launched."
+        ) from e
     out, _ = p.communicate(input=fplll_Ap_encoded)  # output from the flatter run.
     Ap = decode_intmat(out)
     return Ap

--- a/src/generate/genSamples.py
+++ b/src/generate/genSamples.py
@@ -8,6 +8,7 @@ LICENSE file in the root directory of this source tree.
 
 import io
 import os
+import shutil
 import numpy as np
 from time import time
 from glob import glob
@@ -135,13 +136,21 @@ class Generator(object):
         self.logger.info(f"Worker {self.thread} starting new flatter run.")
         fplll_Ap = IntegerMatrix.from_matrix(Ap.tolist())
         fplll_Ap_encoded = encode_intmat(fplll_Ap)
+        flatter_path = shutil.which("flatter")
+        if flatter_path is None:
+            raise RuntimeError(
+                "'flatter' not found on PATH. Install it and make sure it is on your PATH. "
+                "See https://github.com/keeganryan/flatter"
+            )
         try:
             env = {**os.environ, "OMP_NUM_THREADS": "1"}
             p = Popen(
                 ["flatter", "-alpha", str(self.alpha)], stdin=PIPE, stdout=PIPE, env=env
             )
         except Exception as e:
-            raise RuntimeError("Could not launch 'flatter'. Is it installed and on PATH?") from e
+            raise RuntimeError(
+                f"'flatter' was found at '{flatter_path}' but could not be launched."
+            ) from e
         out, _ = p.communicate(input=fplll_Ap_encoded)  # output from the flatter run.
         Ap = decode_intmat(out)
         if self.params.rand_rows:

--- a/src/generate/genSamples.py
+++ b/src/generate/genSamples.py
@@ -145,7 +145,7 @@ class Generator(object):
         try:
             env = {**os.environ, "OMP_NUM_THREADS": "1"}
             p = Popen(
-                ["flatter", "-alpha", str(self.alpha)], stdin=PIPE, stdout=PIPE, env=env
+                [flatter_path, "-alpha", str(self.alpha)], stdin=PIPE, stdout=PIPE, env=env
             )
         except Exception as e:
             raise RuntimeError(

--- a/src/generate/genSamples.py
+++ b/src/generate/genSamples.py
@@ -138,10 +138,10 @@ class Generator(object):
         try:
             env = {**os.environ, "OMP_NUM_THREADS": "1"}
             p = Popen(
-                ["/private/home/ewenger/usr/bin/flatter", "-alpha", str(self.alpha)], stdin=PIPE, stdout=PIPE, env=env
+                ["flatter", "-alpha", str(self.alpha)], stdin=PIPE, stdout=PIPE, env=env
             )
         except Exception as e:
-            self.logger.info(f"flatter failed with error {e}")
+            raise RuntimeError("Could not launch 'flatter'. Is it installed and on PATH?") from e
         out, _ = p.communicate(input=fplll_Ap_encoded)  # output from the flatter run.
         Ap = decode_intmat(out)
         if self.params.rand_rows:

--- a/src/generate/preprocess.py
+++ b/src/generate/preprocess.py
@@ -92,7 +92,7 @@ def get_parser():
         "--float_type",
         type=str,
         default="dd",
-        help="double, long double, dpe, dd, qd, or mpfr_<precision>",
+        help="double, long double, dpe, dd, qd, or mpfr_<precision>. Note: dd/qd require fpylll built with QD support (use environment.yml via conda-forge, not pip).",
     )
     parser.add_argument(
         "--lll_penalty", type=int, default=1, help="penalty on norm of LLL Reduced A"


### PR DESCRIPTION
This PR fixes three issues that block external contributors from running
the preprocessing pipeline. All three were found by reading the actual
code paths in src/generate/genSamples.py, src/cruel_cool/reduction.py,
and src/generate/preprocess.py, not inferred from the README.

1. Hardcoded internal path for flatter

run_flatter_once() in genSamples.py calls
"/private/home/ewenger/usr/bin/flatter" directly. This is a personal
home directory path on an internal cluster, so the call fails
immediately for anyone outside that environment.

For comparison, the equivalent function in src/cruel_cool/reduction.py
already calls plain "flatter" and resolves it through $PATH. Looking at
the history, commit dd81ace ("minor tweak") is what replaced the
portable call in genSamples.py with this hardcoded path — it looks like
a local debugging change that never got reverted before merge.

Fix: resolve the binary location with shutil.which("flatter") instead of
hardcoding a path, and use the resolved path everywhere downstream so
the same binary that was checked is the one actually launched.

2. Silent failure when flatter can't be launched

In both genSamples.py and reduction.py, the same pattern appears:

  try:
      p = Popen(["flatter", ...])
  except Exception as e:
      logger.info/error(f"flatter failed with error {e}")
  out, _ = p.communicate(...)

If Popen raises (binary missing, not executable, etc.), the except
block only logs and execution falls through to p.communicate() with an
undefined p, raising a confusing NameError instead of telling the user
what actually went wrong.

Fix: raise a clear RuntimeError in both files — one message if flatter
isn't found on PATH at all, a different one if it's found but fails to
launch (with the resolved path included for debugging).

3. float_type default ("dd") and pip-installed fpylll

I initially assumed this needed a code fix too (a fallback loop through
FLOAT_UPGRADE), since pip-installed fpylll doesn't ship with QD support
and raises "Float type 'dd' unknown". But I tested the actual
conda-forge build from environment/environment.yml (conda create -c
conda-forge python=3.10 fpylll), and dd/qd both work fine there — the
QD library gets pulled in automatically as a dependency. So this is a
pip-vs-conda installation difference, not a logic bug, and I scoped the
fix down to just clarifying this in --help text rather than touching
the reduction logic.

Testing

- Verified bug #1 by reading the diff in commit dd81ace and confirming
  src/cruel_cool/reduction.py still has the portable version.
- Verified bug #3's severity directly: built fpylll via conda-forge in
  a clean environment and ran GSO.Mat(..., float_type=ft) for
  double/long double/dd/qd — all succeeded. Repeated the same test with
  a plain pip install of fpylll, where dd and qd both raised "Float
  type unknown", confirming the conda-forge env (already the one
  environment.yml points to) isn't affected.
- Tested the new error-handling logic directly for all three paths:
  flatter missing from PATH, flatter present but failing to launch,
  and flatter present and launching successfully. All three behave as
  expected.