### PR TITLE
Implement run_lll_once in InterleavedReduction

### DIFF
--- a/src/generate/genSamples.py
+++ b/src/generate/genSamples.py
@@ -184,8 +184,27 @@ class Generator(object):
         return Ap
 
     def run_lll_once(self, Ap):
-        # TODO this should run the LLL algo from fpylll
-        raise NotImplementedError("This is not implemented yet.")
+        """
+        Runs a single round of LLL.
+        """
+        self.logger.info(f"Worker {self.thread} starting new LLL run.")
+        fplll_Ap = IntegerMatrix.from_matrix(Ap.tolist())
+        M = GSO.Mat(fplll_Ap, float_type=self.float_type, update=True)
+        try:
+            lll_obj = LLL.Reduction(M, delta=self.delta)
+            lll_obj()
+        except Exception as e:
+            self.logger.info(e)
+            self.set_float_type(FLOAT_UPGRADE[self.float_type])
+            self.logger.info(f"Error running LLL. Upgrading to float type {self.float_type}.")
+            M = GSO.Mat(fplll_Ap, float_type=self.float_type, update=True)
+            lll_obj = LLL.Reduction(M, delta=self.delta)
+            lll_obj()
+        Ap = np.zeros((Ap.shape[0], Ap.shape[1]), dtype=np.int64)
+        fplll_Ap.to_matrix(Ap)
+        if self.params.rand_rows:
+            Ap = np.random.permutation(Ap)
+        return Ap
 
     def compute_stdev(self, Ap, UT, use_polish=True, save=True, algo="flatter"):
         if use_polish:


### PR DESCRIPTION
## What

`run_lll_once` in `src/generate/genSamples.py` was a stub that just raised
`NotImplementedError`. I implemented it with `fpylll.LLL.Reduction`, following
the same structure as `run_bkz_once` right above it in the same class.

## Why

`LLL` is listed as a valid option for `--algo` / `--algo2` in `preprocess.py`
(it's in the argparse `choices`), but picking it crashed the worker as soon as
the interleaving logic tried to switch to it. So in practice `--algo2 LLL` was
dead — selectable but unusable. The same stub is also inherited by `DualHybrid`
in `src/dual_hybrid_mitm/run_attack.py`, which subclasses `InterleavedReduction`.

## Implementation

Same flow as `run_bkz_once`: `numpy → IntegerMatrix → GSO.Mat` with
`self.float_type`, run the reduction, copy back to `int64`. I used `self.delta`
(the same delta the BKZ path already passes to its internal LLL reduction), kept
the `FLOAT_UPGRADE` fallback on exception, and honored `rand_rows` so it behaves
like the other reduction methods in the class.

## Testing

Ran on the toy dataset (n=80, log2q=7) with `--algo flatter --algo2 LLL`.

Before, switching to LLL aborted the worker:

```
Stalled, switching from flatter to LLL.
Exception This is not implemented yet. encountered by worker 0, aborting.
```

After, LLL runs, reduces the matrix, and the interleaving alternates cleanly:

```
Stalled, switching from flatter to LLL.
Worker 0 starting new LLL run.
stddev = 0.5589901001427984. Saved progress ... after LLL run.
Worker 0 starting new LLL run.
stddev = 0.5590728708676529. Saved progress ... after LLL run.
Worker 0 starting new LLL run.
stddev = 0.5547387994774072. Saved progress ... after LLL run.
Stalled, switching from LLL to flatter.
Worker 0 starting new flatter run.
stddev = 0.5334584633590501. Saved progress ... after flatter run.
```

stddev came down over the run (~0.59 → ~0.50). On this small toy lattice LLL
converges slowly and didn't reach the stop threshold in a short run — I was
checking that the LLL path actually executes and reduces instead of crashing,
not benchmarking its quality.